### PR TITLE
Remove arbitrary windowed resolution

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -104,10 +104,6 @@ func start_game():
 	match $Panel/TabContainer/Settings/DisplayPanel/FullscreenOptions.selected:
 		0:
 			args.append("-win")
-			args.append("-width")
-			args.append("1280")
-			args.append("-height")
-			args.append("800")
 		1:
 			args.append("+fullscreen 1")
 			args.append("-width")


### PR DESCRIPTION
My screen is bigger than the max resolution so I usually play in windowed at max res, but with this launcher I can't do that even if passing the resolution as manual arguments, so I think it would be best to just let the user input the resolution as an argument or just change it in the game's settings